### PR TITLE
Implemented container:'panel' to open in new window

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 this is a little chrome app wrapper so the open source slack clone, ["mattermost"](http://www.mattermost.com/) can be run in an isolated chrome window that opens links in the main chrome instance. Since it's a chrome app, you can pin the app icon to the windows start menu.  clicking links in chat open in Chrome, not in the chat window.
 
-This is unofficial, not related or approved by anyone, but it is working nicely for myself and my team.  
+This is unofficial, not related or approved by anyone, but it is working nicely for myself and my team.
 
 
 I only tried this in Windows 7 using Chrome stable, it will probably work anywhere chrome runs, give it a try!
@@ -17,7 +17,7 @@ This is a chrome extension that provides a web wrapper to make mattermost chat w
 4. enable checkmark "Developer mode" (this will let you install an unpacked local extension)
 5. click "Load unpacked extension"
 6. browse to and select the folder you cloned this project into.
-7. open url chrome://apps/ , there should be a white icon for "Mattermost Chrome App", right click on it, click "App Info". change from "Open in Tab" to "Open as window", click "Create shortcuts".
+7. open url chrome://apps/ , there should be a white icon for "Mattermost Chrome App", right click on it, click "App Info".  Click "Create shortcuts".
 8. Now you should have an icon in your taskbar quick launch and start menu to directly open Mattermost chat.
 
 ## To pack the extension
@@ -30,7 +30,7 @@ This is a chrome extension that provides a web wrapper to make mattermost chat w
 ## To install packed extension
 1. in chrome, go to url chrome://apps
 2. open windows explorer, navigate to the folder you saved mattermost_chrome_app.crx file into. drag and drop that file onto the chrome://apps window.
-3. that should have added an white icon for "Mattermost Chrome App", right click on it, click "App Info". change from "Open in Tab" to "Open as window", click "Create shortcuts".
+3. that should have added an white icon for "Mattermost Chrome App", right click on it, click "App Info".  Click "Create shortcuts".
 4. Now you should have an icon in your taskbar quick launch and start menu to directly open Mattermost chat.
 
 ## Bonus Custom CSS

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,8 @@
 			"http://mattermost.example.com/your-url/"
 			],
 		"launch": {
-			"web_url": "http://mattermost.example.com/your-url/"
+			"web_url": "http://mattermost.example.com/your-url/",
+			"container": "panel"
 		}
 	},
 	"permissions": [


### PR DESCRIPTION
I tried building this and didn't see any options to open the chrome app in a new tab in my version of chrome, Version 48.0.2564.103 (64-bit).  After some light research I came across: http://stackoverflow.com/questions/20494094/open-chrome-bookmark-app-in-new-window for details.  I also updated the README.md accordingly.
